### PR TITLE
Fix JS-0704 - Disallow the <template> <script> <style> block to be empty

### DIFF
--- a/src/js/components/profile/ProfileInformation.vue
+++ b/src/js/components/profile/ProfileInformation.vue
@@ -254,5 +254,3 @@ export default {
 	},
 };
 </script>
-
-<style></style>


### PR DESCRIPTION
# Description

I have remove the unused style block to remove the code smell JS-0704. 

bug fixes # (bugs from https://bugzilla.nearbeach.org)

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Database change that requires a migration
-   [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

-   [ ] Local manual testing via "./manage runserver"
-   [ ] Local Python Unit Testing via "./manage test"
-   [ ] Local Cypress E2E Testing
-   [ ] Tested on virtual box
-   [ ] Tested on server

# Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
