### PR TITLE
Add event hooks for extendibility

### DIFF
--- a/NearBeach/event_hooks.py
+++ b/NearBeach/event_hooks.py
@@ -1,0 +1,86 @@
+from collections import defaultdict, namedtuple
+from itertools import zip_longest
+
+
+ValueTypes = namedtuple("ValueTypes", ("expected", "got"))
+
+class Registry(defaultdict):
+    """A registy of event types and the hooks to call when they are emitted"""
+
+    def __init__(self, init=None, /, *args, **kwargs):
+        super().__init__(init, *args, **kwargs)
+        self._types = {}
+
+    def register_func(self, event_type):
+        """register function against event type"""
+        def wrapper(func):
+            self[event_type].append(func)
+            return func
+
+        return wrapper
+
+    def register_event_type(self, event_type, *value_type):
+        # Use dict keys to register event types
+        if event_type in self:
+            if self._types[event_type] != value_type:
+                raise ValueError(f"event with same name '{event_type}' but different types {self._types[event_type]} != {value_type}")
+        else:
+            self[event_type]
+            self._types[event_type] = value_type
+
+    def _check_value_types(self, event_type, values):
+        types = []
+        incorrect_found=False
+        for v, t in zip_longest(values, self._types[event_type]):
+            types.append(ValueTypes(expected=t, got=v))
+            if v is None and t is None:
+                continue
+
+            if (
+                (v is None and t is not None) or
+                (v is not None and t is None) or
+                not isinstance(v, t)
+            ):
+                incorrect_found = True
+
+        if incorrect_found:
+            value_types = [
+                f"(expected={v.expected}, got={v.got}({type(v.got)}))"
+                for v in types
+            ]
+            # TODO: log error
+            print(f"ERROR: Emit for event {event_type} submitted with an incorrect type submitted values [{', '.join(value_types)}]")
+            return False
+        return True
+
+    def emit(self, event_type, *values):
+        """call registered functions for a given event type"""
+
+        if not self._check_value_types(event_type, values):
+            return
+
+        for func in self.get(event_type, []):
+            func(*values)
+
+_registry = Registry(list)
+
+# Hide registry via proxy functions
+
+def register_event_type(event_type, value_type):
+    return _registry.register_event_type(event_type, value_type)
+
+def emit(event_type, value):
+    return _registry.emit(event_type, value)
+
+def register_func(event_type):
+    return _registry.register_func(event_type)
+
+
+EventType = namedtuple("EventType", ("name", "types"))
+
+def list_event_types():
+    return [
+        EventType(name=event_name, types=_registry._types[event_name])
+        for event_name in _registry.keys()
+    ]
+

--- a/NearBeach/management/commands/listevents.py
+++ b/NearBeach/management/commands/listevents.py
@@ -1,0 +1,45 @@
+from django.core.management.base import BaseCommand
+from NearBeach import event_hooks
+
+# Import runschedular so that we get its events
+from . import runscheduler as _
+
+class Command(BaseCommand):
+    help = "Lists registered event which can be hooked onto"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--prefix", action='append', type=str)
+
+    @staticmethod
+    def _has_prefix(event_name, prefixes):
+        return any(
+            event_name.startswith(p)
+            for p in prefixes
+        )
+
+    def handle(self, *args, **options):
+        print("options:", options)
+
+        prefixes = options.get("prefix")
+        prefix_msg_modifier=""
+        if prefixes is None:
+            prefixes = [""]
+        else:
+            prefix_msg_modifier = f"have the following prefixes [{', '.join(prefixes)}] " # Note needs trailing space
+
+
+        found = []
+        for e in sorted(event_hooks.list_event_types(), key=lambda e: e.name):
+            if self._has_prefix(e.name, prefixes):
+                found.append(f"- {e.name} ({", ".join(str(x) for x in e.types)})")
+
+        if len(found) == 0:
+            if prefix_msg_modifier == "":
+                print("No events found")
+            else:
+                print(f"No events that {prefix_msg_modifier}found")
+        else:
+            print(f"These are the events currently registered for event which {prefix_msg_modifier}can be hooked onto:")
+            print("key: event_name (arg types)")
+            for line in found:
+                print(line)

--- a/NearBeach/tests/tests_event_hooks/test_event_hooks.py
+++ b/NearBeach/tests/tests_event_hooks/test_event_hooks.py
@@ -1,0 +1,30 @@
+from NearBeach import event_hooks
+from django.test import TestCase
+from unittest import mock
+
+
+
+class EventHooksEmitTest(TestCase):
+    def setUp(self):
+        self._registry = event_hooks.Registry(list)
+        self._registry.register_event_type("test", str)
+        self._mock = mock.MagicMock()
+        self._registry.register_func("test")(self._mock)
+        self._patch_print = mock.patch("builtins.print")
+
+
+    def test_emit_with_valid(self):
+        self._registry.emit("test", "test_value")
+        self._mock.assert_called_with("test_value")
+
+    def test_emit_with_invalid_type(self):
+        with self._patch_print as patched:
+            self._registry.emit("test", 1)
+        patched.assert_called_once()
+        self._mock.assert_not_called()
+
+    def test_emit_with_too_many_types(self):
+        with self._patch_print as patched:
+            self._registry.emit("test", "test_value", "invalid")
+        patched.assert_called_once()
+        self._mock.assert_not_called()

--- a/NearBeach/views/api/kanban_card_api_view.py
+++ b/NearBeach/views/api/kanban_card_api_view.py
@@ -13,7 +13,10 @@ from NearBeach.models import (
 from NearBeach.serializers.kanban_card_serializer import KanbanCardSerializer
 from NearBeach.serializers.tag_serializer import TagSerializer
 from NearBeach.decorators.check_user_permissions.api_permissions_v0 import check_user_api_permissions
+from NearBeach import event_hooks
 
+
+event_hooks.register_event_type("kanban_card.create", KanbanCard)
 
 class KanbanCardViewSet(viewsets.ModelViewSet):
     queryset = KanbanCard.objects.filter(is_deleted=False)
@@ -85,6 +88,7 @@ class KanbanCardViewSet(viewsets.ModelViewSet):
             change_user=request.user,
         )
         kanban_card_submit.save()
+        event_hooks.emit("kanban_card.create", kanban_card_submit)
 
         # Get the new kanban card and send to user
         kanban_card_results = KanbanCard.objects.get(
@@ -180,7 +184,7 @@ class KanbanCardViewSet(viewsets.ModelViewSet):
 
         # Get the update kanban card
         update_kanban_card = update_kanban_card[0]
-        
+
         # Flatpack serializer data
         new_column = serializer.validated_data['kanban_column_id']
         new_level = serializer.validated_data['kanban_level_id']
@@ -200,7 +204,7 @@ class KanbanCardViewSet(viewsets.ModelViewSet):
         # Get old level and column
         old_level = update_kanban_card.kanban_level
         old_column = update_kanban_card.kanban_column
-        
+
         # Check to see if the card has been moved
         if new_column != old_column or new_level != old_level:
             # Card has been moved

--- a/NearBeach/views/api/task_api_view.py
+++ b/NearBeach/views/api/task_api_view.py
@@ -12,7 +12,9 @@ from NearBeach.serializers.task_serializer import TaskSerializer
 from rest_framework import viewsets, status
 from rest_framework.response import Response
 from NearBeach.views.document_views import transfer_new_object_uploads
+from NearBeach import event_hooks
 
+event_hooks.register_event_type("task.create", Task)
 
 class TaskViewSet(viewsets.ModelViewSet):
     # Setup the queryset and serialiser class
@@ -58,6 +60,7 @@ class TaskViewSet(viewsets.ModelViewSet):
 
         )
         task_submit.save()
+        event_hooks.emit("task.create", task_submit)
 
         # Assign task to the groups
         for single_group in group_list:


### PR DESCRIPTION
- Events can be used to register functions which can be used to react to events.

- Adds mangment command to list registered events:
    > python3 manage.py listevents
  which can be filtered with prefixes:
    > python3 manage.py listevents --prefix task --prefix kanban

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

bug fixes # (bugs from https://bugzilla.nearbeach.org)

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Database change that requires a migration
-   [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

-   [ ] Local manual testing via "./manage runserver"
-   [X] Local Python Unit Testing via "./manage test"
-   [ ] Local Cypress E2E Testing
-   [ ] Tested on virtual box
-   [ ] Tested on server

# Checklist:

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
